### PR TITLE
Remove development files from archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
 /.gitattributes export-ignore
+/.github export-ignore
 /.gitignore export-ignore
 /docker-compose.yml export-ignore
 /Dockerfile export-ignore
+/icon.svg export-ignore
 /phpcs.xml export-ignore
 /phpmd.xml export-ignore
 /phpunit.xml export-ignore


### PR DESCRIPTION
This PR removes development files from production package checking `composer archive`.