### PR TITLE
Dependencies

### DIFF
--- a/src/Planner/Exception.php
+++ b/src/Planner/Exception.php
@@ -9,4 +9,5 @@ use Exception as BaseException;
 class Exception extends BaseException
 {
     const DEPENDENCY_CIRCULAR = 1;
+    const DEPENDENCY_INVALID  = 2;
 }

--- a/src/Planner/Planner.php
+++ b/src/Planner/Planner.php
@@ -111,6 +111,15 @@ class Planner
         $dependents = [];
 
         foreach ($this->getContainer() as $migration) {
+            foreach ($migration->getDependencies() as $dependency) {
+                if (! is_string($dependency)) {
+                    throw new Exception(
+                        sprintf('Invalid Migration "%s" Dependency Data Type: "%s"', $name, gettype($dependency)),
+                        Exception::DEPENDENCY_INVALID,
+                    );
+                }
+            }
+
             // Resolve Unknown Dependents
             $resolver     = fn($dependency) => $this->getContainer()->getMigration($dependency)->getName();
             $dependencies = array_map($resolver, $migration->getDependencies());

--- a/src/Planner/Planner.php
+++ b/src/Planner/Planner.php
@@ -51,6 +51,13 @@ class Planner
         $visited->addMigration($migration);
 
         foreach ($migration->getDependencies() as $dependency) {
+            if (! is_string($dependency)) {
+                throw new Exception(
+                    sprintf('Invalid Migration "%s" Dependency Data Type: "%s"', $name, gettype($dependency)),
+                    Exception::DEPENDENCY_INVALID,
+                );
+            }
+
             if ($visited->hasMigration($dependency)) {
                 $path   = $visited->getMigrationNames();
                 $path[] = $dependency;

--- a/tests/Migration/ContainerTest.php
+++ b/tests/Migration/ContainerTest.php
@@ -79,4 +79,13 @@ class ContainerTest extends TestCase
         // Dependencies are **NOT** Resolved by Container
         $this->container->addMigration($this->createMigration('A', ['B']));
     }
+
+    public function testMigrationAllowInvalidDependency(): void
+    {
+        // Everything must Work
+        $this->expectNotToPerformAssertions();
+
+        // Dependencies are **NOT** Resolved by Container
+        $this->container->addMigration($this->createMigration('A', [3.1415]));
+    }
 }

--- a/tests/Planner/ExceptionTest.php
+++ b/tests/Planner/ExceptionTest.php
@@ -23,5 +23,6 @@ class ExceptionTest extends TestCase
     public function testCodes(): void
     {
         $this->assertSame(1, Exception::DEPENDENCY_CIRCULAR);
+        $this->assertSame(2, Exception::DEPENDENCY_INVALID);
     }
 }

--- a/tests/Planner/PlannerDownTest.php
+++ b/tests/Planner/PlannerDownTest.php
@@ -48,6 +48,19 @@ class PlannerDownTest extends TestCase
         $this->assertSame(['B', 'A'], $this->planner->down()->getMigrationNames());
     }
 
+    public function testDependenciesInvalid(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(Exception::DEPENDENCY_INVALID);
+        $this->expectExceptionMessage('Invalid Migration "A" Dependency Data Type: "double"');
+
+        $container = $this->planner->getContainer();
+
+        $container->addMigration($this->createMigration('A', [3.1415]));
+
+        $this->planner->down();
+    }
+
     public function testDependenciesDeep(): void
     {
         $container = $this->planner->getContainer();

--- a/tests/Planner/PlannerUpTest.php
+++ b/tests/Planner/PlannerUpTest.php
@@ -48,6 +48,19 @@ class PlannerUpTest extends TestCase
         $this->assertSame(['B', 'A'], $this->planner->up()->getMigrationNames());
     }
 
+    public function testInvalidDependencies(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(Exception::DEPENDENCY_INVALID);
+        $this->expectExceptionMessage('Invalid Migration "A" Dependency Data Type: "float"');
+
+        $container = $this->planner->getContainer();
+
+        $container->addMigration($this->createMigration('A', [3.1415]));
+
+        $this->planner->up();
+    }
+
     public function testDependenciesDeep(): void
     {
         $container = $this->planner->getContainer();

--- a/tests/Planner/PlannerUpTest.php
+++ b/tests/Planner/PlannerUpTest.php
@@ -48,11 +48,11 @@ class PlannerUpTest extends TestCase
         $this->assertSame(['B', 'A'], $this->planner->up()->getMigrationNames());
     }
 
-    public function testInvalidDependencies(): void
+    public function testDependenciesInvalid(): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(Exception::DEPENDENCY_INVALID);
-        $this->expectExceptionMessage('Invalid Migration "A" Dependency Data Type: "float"');
+        $this->expectExceptionMessage('Invalid Migration "A" Dependency Data Type: "double"');
 
         $container = $this->planner->getContainer();
 


### PR DESCRIPTION
This PR fixes `TypeError` exceptions when a dependency is not declared as `string`.