### PR TITLE
Events Clean Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,9 @@ will try to recreate resources.
 
 ### Event Dispatcher
 
-Lastly, Griffin implements PSR-14 Event Dispatcher and triggers events after and
-before migrations up and down. You can use it to create a logger, as example.
+Lastly, Griffin use PSR-14 Event Dispatcher to trigger events after and before
+migrations up and down. You can use it to create a logger, as example, using
+`league/event` package or any PSR-14 implementation.
 
 ```php
 use FooBar\Database\Migration;

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "psr/event-dispatcher": "1.0.*"
   },
   "require-dev": {
-    "league/event": "3.0.*",
     "php-parallel-lint/php-parallel-lint": "1.3.*",
     "phpmd/phpmd": "2.9.*",
     "phpunit/phpunit": "9.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69b90d186a924e553e1ef4c63d88def7",
+    "content-hash": "58e1f847db6b371eec2d4dc501c4ea1f",
     "packages": [
         {
             "name": "psr/event-dispatcher",
@@ -260,65 +260,6 @@
                 }
             ],
             "time": "2020-11-10T18:47:58+00:00"
-        },
-        {
-            "name": "league/event",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/event.git",
-                "reference": "6d6d88d3c398f4e32995fccd4ec50a5bdaef131b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/event/zipball/6d6d88d3c398f4e32995fccd4ec50a5bdaef131b",
-                "reference": "6d6d88d3c398f4e32995fccd4ec50a5bdaef131b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0",
-                "psr/event-dispatcher": "^1.0"
-            },
-            "provide": {
-                "psr/event-dispatcher-implementation": "1.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.16",
-                "phpstan/phpstan": "^0.12.45",
-                "phpunit/phpunit": "^8.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\Event\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Frank de Jonge",
-                    "email": "info@frenky.net"
-                }
-            ],
-            "description": "Event package",
-            "keywords": [
-                "emitter",
-                "event",
-                "listener"
-            ],
-            "support": {
-                "issues": "https://github.com/thephpleague/event/issues",
-                "source": "https://github.com/thephpleague/event/tree/3.0.0"
-            },
-            "time": "2020-09-29T17:42:28+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -6,8 +6,8 @@ namespace GriffinTest\Runner;
 
 use Griffin\Planner\Planner;
 use Griffin\Runner\Runner;
-use League\Event\EventDispatcher;
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 
 class RunnerTest extends TestCase
 {
@@ -27,7 +27,7 @@ class RunnerTest extends TestCase
 
     public function testEventDispatcher(): void
     {
-        $dispatcher = new EventDispatcher();
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $this->assertNull($this->runner->getEventDispatcher());
         $this->assertSame($this->runner, $this->runner->setEventDispatcher($dispatcher));


### PR DESCRIPTION
This PR removes develop requirement from `league/event` and uses mocks to test behaviors.